### PR TITLE
Support vectorized envs and gym env improvements

### DIFF
--- a/hacking_testing/minetest_env.py
+++ b/hacking_testing/minetest_env.py
@@ -1,21 +1,18 @@
+import datetime
+import logging
 import os
+import random
+import shutil
 import subprocess
 import uuid
+from typing import Any, Dict, Optional, Tuple
 
 import gym
 import matplotlib.pyplot as plt
 import numpy as np
 import zmq
-from gym.spaces import Box, Dict, Discrete
 from proto_python.client import dumb_inputs_pb2 as dumb_inputs
 from proto_python.client import dumb_outputs_pb2 as dumb_outputs
-
-# TODO read from the minetest.conf file
-DISPLAY_SIZE = (1024, 600)
-FOV_Y = 72  # degrees
-FOV_X = FOV_Y * DISPLAY_SIZE[0] / DISPLAY_SIZE[1]
-MAX_MOUSE_MOVE_X = 180 / FOV_X * DISPLAY_SIZE[0]
-MAX_MOUSE_MOVE_Y = 180 / FOV_Y * DISPLAY_SIZE[1]
 
 KEYS = [
     "FORWARD",
@@ -58,26 +55,24 @@ KEYS = [
 def start_minetest_server(
     minetest_path: str = "bin/minetest",
     config_path: str = "minetest.conf",
-    log_dir: str = "log",
-    world: str = None,
+    log_path: str = "log/{}.log",
+    server_port: int = 30000,
+    world_dir: str = "newworld",
 ):
-    if world:
-        world_path = world
-    else:
-        world_path = str(uuid.uuid4())
     cmd = [
         minetest_path,
         "--server",
         "--world",
-        world_path,
+        world_dir,
         "--gameid",
-        "minetest",
+        "minetest",  # TODO does this have to be unique?
         "--config",
         config_path,
+        "--port",
+        str(server_port),
     ]
-    os.makedirs(log_dir, exist_ok=True)
-    stdout_file = os.path.join(log_dir, "server_stdout.log")
-    stderr_file = os.path.join(log_dir, "server_stderr.log")
+    stdout_file = log_path.format("server_stdout")
+    stderr_file = log_path.format("server_stderr")
     with open(stdout_file, "w") as out, open(stderr_file, "w") as err:
         server_process = subprocess.Popen(cmd, stdout=out, stderr=err)
     return server_process
@@ -85,8 +80,10 @@ def start_minetest_server(
 
 def start_minetest_client(
     minetest_path: str = "bin/minetest",
-    log_dir: str = "log",
+    config_path: str = "minetest.conf",
+    log_path: str = "log/{}.log",
     client_port: int = 5555,
+    server_port: int = 30000,
     cursor_img: str = "cursors/mouse_cursor_white_16x16.png",
     client_name: str = "MinetestAgent",
 ):
@@ -99,20 +96,21 @@ def start_minetest_client(
         "--address",
         "0.0.0.0",  # listen to all interfaces
         "--port",
-        "30000",  # TODO this should be the same as in minetest.conf
+        str(server_port),
         "--go",
         "--dumb",
         "--client-address",
         "tcp://localhost:" + str(client_port),
         "--record",
         "--noresizing",
+        "--config",
+        config_path,
     ]
     if cursor_img:
         cmd.extend(["--cursor-image", cursor_img])
 
-    os.makedirs(log_dir, exist_ok=True)
-    stdout_file = os.path.join(log_dir, "client_stdout.log")
-    stderr_file = os.path.join(log_dir, "client_stderr.log")
+    stdout_file = log_path.format("client_stdout")
+    stderr_file = log_path.format("client_stderr")
     with open(stdout_file, "w") as out, open(stderr_file, "w") as err:
         client_process = subprocess.Popen(cmd, stdout=out, stderr=err)
     return client_process
@@ -123,71 +121,203 @@ class Minetest(gym.Env):
 
     def __init__(
         self,
-        socket_port: int = 5555,
-        minetest_executable: os.PathLike = None,
-        log_dir: os.PathLike = None,
-        config_path: os.PathLike = None,
+        env_port: int = 5555,
+        server_port: int = 30000,
+        minetest_executable: Optional[os.PathLike] = None,
+        log_dir: Optional[os.PathLike] = None,
+        config_path: Optional[os.PathLike] = None,
+        cursor_image_path: Optional[os.PathLike] = None,
+        world_dir: Optional[os.PathLike] = None,
+        display_size: Tuple[int, int] = (1024, 600),
+        fov: int = 72,
+        seed: Optional[int] = None,
     ):
+        # Graphics settings
+        self.display_size = display_size
+        self.fov_y = fov
+        self.fov_x = self.fov_y * self.display_size[0] / self.display_size[1]
+        self.max_mouse_move_x = 180 / self.fov_x * self.display_size[0]
+        self.max_mouse_move_y = 180 / self.fov_y * self.display_size[1]
+
         # Define action and observation space
-        self.action_space = Dict(
+        self.action_space = gym.spaces.Dict(
             {
-                **{key.lower(): Discrete(2) for key in KEYS},
+                **{key.lower(): gym.spaces.Discrete(2) for key in KEYS},
                 **{
-                    "mouse": Box(
-                        np.array([-MAX_MOUSE_MOVE_X, -MAX_MOUSE_MOVE_Y]),
-                        np.array([MAX_MOUSE_MOVE_X, MAX_MOUSE_MOVE_Y]),
+                    "mouse": gym.spaces.Box(
+                        np.array([-self.max_mouse_move_x, -self.max_mouse_move_y]),
+                        np.array([self.max_mouse_move_x, self.max_mouse_move_y]),
                         shape=(2,),
                         dtype=int,
                     ),
                 },
             },
         )
-        self.observation_space = Box(0, 255, shape=(*DISPLAY_SIZE, 3), dtype=np.uint8)
+        self.observation_space = gym.spaces.Box(
+            0,
+            255,
+            shape=(self.display_size[1], self.display_size[0], 3),
+            dtype=np.uint8,
+        )
 
-        root_dir = os.path.dirname(os.path.dirname(__file__))
+        # Define Minetest paths
+        self.root_dir = os.path.dirname(os.path.dirname(__file__))
         if minetest_executable is None:
-            minetest_executable = os.path.join(root_dir, "bin", "minetest")
+            self.minetest_executable = os.path.join(self.root_dir, "bin", "minetest")
         if log_dir is None:
-            log_dir = os.path.join(root_dir, "log")
-        if config_path is None:
-            config_path = os.path.join(root_dir, "minetest.conf")
+            self.log_dir = os.path.join(self.root_dir, "log")
+        os.makedirs(self.log_dir, exist_ok=True)
+        self.world_dir = world_dir
+        self.config_path = config_path
+        if cursor_image_path is None:
+            self.cursor_image_path = os.path.join(
+                self.root_dir,
+                "cursors",
+                "mouse_cursor_white_16x16.png",
+            )
 
-        # TODO we might want to also restart server and/or client when calling reset()
-        # in some situations, e.g. in episodic RL tasks the world should be reset
-        # Start Minetest server and client
-        self.server_process = start_minetest_server(
-            minetest_executable, config_path, log_dir, "newworld",
-        )
-        self.client_process = start_minetest_client(
-            minetest_executable, log_dir, socket_port,
-        )
+        # Regenerate and clean world if no custom world provided
+        self.reset_world = self.world_dir is None
 
-        # Setup ZMQ
-        self.socket_port = socket_port
-        self.context = zmq.Context()
-        self.socket = self.context.socket(zmq.REP)
-        self.socket.bind(f"tcp://*:{self.socket_port}")
+        # Clean config if no custom config provided
+        self.clean_config = self.config_path is None
 
+        # Used ports
+        self.env_port = env_port  # MT env <-> MT client
+        self.server_port = server_port  # MT client <-> MT server
+
+        # ZMQ objects
+        self.socket = None
+        self.context = None
+
+        # Minetest processes
+        self.server_process = None
+        self.client_process = None
+
+        # Env objects
         self.last_obs = None
         self.render_fig = None
         self.render_img = None
 
-    def reset(self):
-        print("Waiting for obs...")
-        byte_obs = self.socket.recv()
+        # Seed the environment
+        self.unique_env_id = str(uuid.uuid4())  # fallback UUID when no seed is provided
+        if seed:
+            self.seed(seed)
+
+        # Configure logging
+        logging.basicConfig(
+            filename=os.path.join(self.log_dir, f"env_{self.unique_env_id}.log"),
+            filemode="a",
+            format='%(asctime)s,%(msecs)d %(name)s %(levelname)s %(message)s',
+            datefmt='%H:%M:%S',
+            level=logging.DEBUG,
+        )
+
+    def _reset_zmq(self):
+        if self.socket:
+            self.socket.close()
+        self.context = zmq.Context()
+        self.socket = self.context.socket(zmq.REP)
+        self.socket.bind(f"tcp://*:{self.env_port}")
+
+    def _reset_minetest(self):
+        # Determine log paths
+        reset_timestamp = datetime.datetime.now().strftime("%m-%d-%Y,%H:%M:%S")
+        log_path = os.path.join(
+            self.log_dir, f"{{}}_{reset_timestamp}_{self.unique_env_id}.log",
+        )
+
+        # (Re)start Minetest server
+        if self.server_process:
+            self.server_process.kill()
+        self.server_process = start_minetest_server(
+            self.minetest_executable,
+            self.config_path,
+            log_path,
+            self.server_port,
+            self.world_dir,
+        )
+
+        # (Re)start Minetest client
+        if self.client_process:
+            self.client_process.kill()
+        self.client_process = start_minetest_client(
+            self.minetest_executable,
+            self.config_path,
+            log_path,
+            self.env_port,
+            self.server_port,
+            self.cursor_image_path,
+        )
+
+    def _delete_world(self):
+        if self.world_dir is not None:
+            if os.path.exists(self.world_dir):
+                shutil.rmtree(self.world_dir)
+        else:
+            raise RuntimeError(
+                "World directory was not set. Please, provide a world directory"
+                "in the constructor or seed the environment!",
+            )
+
+    def _delete_config(self):
+        if self.config_path is not None:
+            if os.path.exists(self.config_path):
+                os.remove(self.config_path)
+        else:
+            raise RuntimeError(
+                "Minetest config path was not set. Please, provide a config path"
+                "in the constructor or seed the environment!",
+            )
+
+    def _write_config(self):
+        with open(self.config_path, "w") as config_file:
+            # Update default settings
+            config_file.write("mute_sound = true\n")
+            config_file.write("show_debug = false\n")
+
+            # Set display size
+            config_file.write(f"screen_w = {self.display_size[0]}\n")
+            config_file.write(f"screen_h = {self.display_size[1]}\n")
+
+            # Set FOV
+            config_file.write(f"fov = {self.fov_y}\n")
+
+            # Seed the map generator
+            if self.seed:
+                config_file.write(f"fixed_map_seed = {self.seed}\n")
+
+    def seed(self, seed: int):
+        self.seed = seed
+
+        # Create UUID from seed
+        rnd = random.Random()
+        rnd.seed(self.seed)
+        self.unique_env_id = str(uuid.UUID(int=rnd.getrandbits(128), version=4))
+
+        # If not set manually, world and config paths are based on UUID
+        if self.world_dir is None:
+            self.world_dir = os.path.join(self.root_dir, self.unique_env_id)
+        if self.config_path is None:
+            self.config_path = os.path.join(self.root_dir, f"{self.unique_env_id}.conf")
+            self._write_config()
+        # TODO seed used libraries, like numpy, pytorch etc.
+
+    def _unpack_pb_obs(self, received_obs: str):
         pb_obs = dumb_outputs.OutputObservation()
-        pb_obs.ParseFromString(byte_obs)
+        pb_obs.ParseFromString(received_obs)
         obs = np.frombuffer(pb_obs.data, dtype=np.uint8).reshape(
             pb_obs.height,
             pb_obs.width,
             3,
         )
-        self.last_obs = obs
-        print("Received obs: {}".format(obs.shape))
-        return obs
+        # TODO receive rewards etc.
+        rew = 0.0
+        done = False
+        info = {}
+        return obs, rew, done, info
 
-    def step(self, action):
-        # make mouse action serializable
+    def _pack_pb_action(self, action: Dict[str, Any]):
         pb_action = dumb_inputs.InputAction()
         pb_action.mouseDx, pb_action.mouseDy = action["mouse"]
         for key, v in action.items():
@@ -199,8 +329,26 @@ class Minetest(gym.Env):
                     eventType=dumb_inputs.PRESS if v else dumb_inputs.RELEASE,
                 ),
             )
+        return pb_action
 
-        print("Sending action: {}".format(action))
+    def reset(self):
+        if self.reset_world:
+            self._delete_world()
+        self._reset_zmq()
+        self._reset_minetest()
+
+        # Receive initial observation
+        logging.debug("Waiting for first obs...")
+        byte_obs = self.socket.recv()
+        obs, _, _, _ = self._unpack_pb_obs(byte_obs)
+        self.last_obs = obs
+        logging.debug("Received first obs: {}".format(obs.shape))
+        return obs
+
+    def step(self, action: Dict[str, Any]):
+        # Send action
+        logging.debug("Sending action: {}".format(action))
+        pb_action = self._pack_pb_action(action)
         self.socket.send(pb_action.SerializeToString())
 
         # TODO more robust check for whether a server/client is alive while receiving observations
@@ -208,21 +356,12 @@ class Minetest(gym.Env):
             if process.poll() is not None:
                 return self.last_obs, 0.0, True, {}
 
-        print("Waiting for obs...")
+        # Receive observation
+        logging.debug("Waiting for obs...")
         byte_obs = self.socket.recv()
-        pb_obs = dumb_outputs.OutputObservation()
-        pb_obs.ParseFromString(byte_obs)
-        next_obs = np.frombuffer(pb_obs.data, dtype=np.uint8).reshape(
-            pb_obs.height,
-            pb_obs.width,
-            3,
-        )
+        next_obs, rew, done, info = self._unpack_pb_obs(byte_obs)
         self.last_obs = next_obs
-        print("Received obs: {}".format(next_obs.shape))
-        # TODO receive rewards etc.
-        rew = 0.0
-        done = False
-        info = {}
+        logging.debug("Received obs: {}".format(next_obs.shape))
         return next_obs, rew, done, info
 
     def render(self, render_mode: str = "human"):
@@ -240,12 +379,10 @@ class Minetest(gym.Env):
                 plt.rcParams["figure.autolayout"] = True
 
                 self.render_fig = plt.figure(
-                    num="Minetest",
-                    figsize=(3 * DISPLAY_SIZE[0] / DISPLAY_SIZE[1], 3),
+                    num="Minetest Env",
+                    figsize=(3 * self.display_size[0] / self.display_size[1], 3),
                 )
-                self.render_img = self.render_fig.gca().imshow(
-                    self.last_obs,
-                )
+                self.render_img = self.render_fig.gca().imshow(self.last_obs)
                 self.render_fig.gca().axis("off")
                 self.render_fig.gca().margins(0, 0)
                 self.render_fig.gca().autoscale_view()
@@ -258,6 +395,13 @@ class Minetest(gym.Env):
     def close(self):
         if self.render_fig is not None:
             plt.close()
-        self.socket.close()
-        self.client_process.kill()
-        self.server_process.kill()
+        if self.socket is not None:
+            self.socket.close()
+        if self.client_process is not None:
+            self.client_process.kill()
+        if self.server_process is not None:
+            self.server_process.kill()
+        if self.reset_world:
+            self._delete_world()
+        if self.clean_config:
+            self._delete_config()

--- a/hacking_testing/test_loop.py
+++ b/hacking_testing/test_loop.py
@@ -1,6 +1,7 @@
 from minetest_env import Minetest
 
-env = Minetest()
+seed = 42
+env = Minetest(seed=seed)
 obs = env.reset()
 render = False
 done = False

--- a/hacking_testing/test_loop_parallel.py
+++ b/hacking_testing/test_loop_parallel.py
@@ -1,0 +1,57 @@
+from typing import Any, Dict, Optional
+
+from gym.wrappers import TimeLimit
+from minetest_env import Minetest
+from stable_baselines3.common.vec_env import DummyVecEnv, SubprocVecEnv
+
+if __name__ == "__main__":
+
+    def make_env(
+        rank: int,
+        seed: int = 0,
+        max_steps: int = 1e9,
+        env_kwargs: Optional[Dict[str, Any]] = None,
+    ):
+        env_kwargs = env_kwargs or {}
+
+        def _init():
+            # Make sure that each Minetest instance has
+            # - different server and client ports
+            # - different and deterministic seeds
+            env = Minetest(
+                env_port=5555 + rank,
+                server_port=30000 + rank,
+                seed=seed + rank,
+                **env_kwargs,
+            )
+            env = TimeLimit(env, max_episode_steps=max_steps)
+            return env
+
+        return _init
+
+    # Env settings
+    seed = 42
+    max_steps = 100
+    env_kwargs = {"display_size": (600, 400), "fov": 72}
+
+    # Create a vectorized environment
+    num_envs = 2  # Number of envs to use (<= number of avail. cpus)
+    vec_env_cls = SubprocVecEnv  # DummyVecEnv
+    venv = vec_env_cls(
+        [
+            make_env(rank=i, seed=seed, max_steps=max_steps, env_kwargs=env_kwargs)
+            for i in range(num_envs)
+        ],
+    )
+
+    # Start loop
+    render = False
+    obs = venv.reset()
+    done = [False] * num_envs
+    while sum(done) != num_envs:
+        print(f"Elapsed steps: {venv.get_attr('_elapsed_steps')}")
+        actions = [venv.action_space.sample() for _ in range(num_envs)]
+        obs, rew, done, info = venv.step(actions)
+        if render:
+            venv.render()
+    venv.close()


### PR DESCRIPTION
* add test loop for vectorized envs (requires stable baselines3)
* add seeding
* write and load minetest conf, e.g. set display size
* proper reset(), i.e. restart minetest server/client, reset world
* logging

## How to test

- `python hacking_testing/test_loop_parallel.py`
- `python hacking_testing/test_loop.py`