### PR TITLE
Clientmod config

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -68,7 +68,8 @@ newworld/
 /worlds
 /world/
 /clientmods/*
-!/clientmods/preview/
+!/clientmods/rewards/
+!/clientmods/random/
 !/clientmods/treechop/
 !/clientmods/mods.conf
 /client/mod_storage/

--- a/clientmods/mods.conf
+++ b/clientmods/mods.conf
@@ -1,4 +1,4 @@
-load_mod_rewards = false
+load_mod_rewards = true
+load_mod_random = false
+load_mod_treechop = false
 load_mod_preview = false
-load_mod_rewards_client = false
-load_mod_treechop = true

--- a/clientmods/random/init.lua
+++ b/clientmods/random/init.lua
@@ -1,0 +1,4 @@
+-- set random reward at every step
+minetest.register_globalstep(function(dtime)
+    reward = math.random()
+end)

--- a/clientmods/random/mod.conf
+++ b/clientmods/random/mod.conf
@@ -1,0 +1,1 @@
+name = random

--- a/clientmods/rewards/init.lua
+++ b/clientmods/rewards/init.lua
@@ -1,23 +1,7 @@
--- https://github.com/minetest/minetest/issues/10682
-local function register_globalstep_on_mods_loaded(func)
-    local function wrapper_func(dtime)
-         if not minetest.localplayer then return end
-         func(dtime)
-         for i, globalstep in pairs(minetest.registered_globalsteps) do
-              if globalstep == wrapper_func then
-                  minetest.registered_globalsteps[i] = func
-              end
-         end
-    end
-    minetest.register_globalstep(wrapper_func)
-end
+-- define global reward variable
 reward = 0.0
--- local loaded = false
-register_globalstep_on_mods_loaded(function()
-    -- if(loaded) then return end
-    -- loaded = true
-    -- local channel_name = "rewards_"..minetest.localplayer:get_name()
-    -- minetest.mod_channel_join(channel_name)
-    -- minetest.register_on_modchannel_message(function(channel_name, sender, message) end)
-    reward = math.random()
+
+-- reset reward every step
+minetest.register_globalstep(function(dtime)
+    reward = 0.0
 end)

--- a/clientmods/treechop/init.lua
+++ b/clientmods/treechop/init.lua
@@ -1,11 +1,3 @@
-
-reward = 0.0
-
--- reset reward every step
-minetest.register_globalstep(function(dtime)
-    reward = 0.0
-end)
-
 -- reward chopping tree nodes
 minetest.register_on_dignode(function(pos, node)
     if string.find(node["name"], "tree") then


### PR DESCRIPTION
- Makes clientmods configurable in the gym env
- Makes base reward mod define and reset global `reward` variable whereas "task mods" (like treechop) modify it or overwrite it at every step (like the newly added random reward mod)

This PR is a Ready for Review.

## How to test

pass a list of clientmod names (e.g. `clientmods=["treechop"]`) to the constructor in `test_loop.py`
