### PR TITLE
Provide compatibility for SDL packages with no exports

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -38,6 +38,14 @@ mark_as_advanced(EXECUTABLE_OUTPUT_PATH LIBRARY_OUTPUT_PATH)
 
 if(BUILD_CLIENT AND BUILD_HEADLESS)
 	find_package(SDL2 REQUIRED)
+	# SDL2 exports targets since 2.0.6, but some distributions override config.
+	if(NOT TARGET SDL2::SDL2)
+		add_library(SDL2::SDL2 INTERFACE IMPORTED)
+		set_target_properties(SDL2::SDL2 PROPERTIES
+			INTERFACE_INCLUDE_DIRECTORIES ${SDL2_INCLUDE_DIRS}
+			INTERFACE_LINK_LIBRARIES ${SDL2_LIBRARIES}
+		)
+	endif()
 endif()
 
 if(NOT (BUILD_CLIENT OR BUILD_SERVER))


### PR DESCRIPTION
Some versions of SDL2 do not export CMake targets, and some packages do not provide the targets for versions that do export them. This PR extends src/CMakeLists.txt to add an IMPORTED target for SDL2::SDL2 if no export is found.

Implements a solution to #22.

## How to test

Configure the headless build with an SDL2 version less than 2.0.6 or on a system that does not include targets in sdl2-config.cmake. There should be no errors or warnings during configuration. Then compile and confirm that the behavior of the graphics has not changed.

~~ATTENTION: The headless build does not work for me, and I can't test it in the absence of these changes, so I cannot personally vouch for the correctness of this implementation.~~
Edit: I've figured out the other issues and have confirmed that this works.
