### PR TITLE
Fix memleak in render core

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -38,6 +38,14 @@ mark_as_advanced(EXECUTABLE_OUTPUT_PATH LIBRARY_OUTPUT_PATH)
 
 if(BUILD_CLIENT AND BUILD_HEADLESS)
 	find_package(SDL2 REQUIRED)
+	# SDL2 exports targets since 2.0.6, but some distributions override config.
+	if(NOT TARGET SDL2::SDL2)
+		add_library(SDL2::SDL2 INTERFACE IMPORTED)
+		set_target_properties(SDL2::SDL2 PROPERTIES
+			INTERFACE_INCLUDE_DIRECTORIES ${SDL2_INCLUDE_DIRS}
+			INTERFACE_LINK_LIBRARIES ${SDL2_LIBRARIES}
+		)
+	endif()
 endif()
 
 if(NOT (BUILD_CLIENT OR BUILD_SERVER))

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -38,14 +38,6 @@ mark_as_advanced(EXECUTABLE_OUTPUT_PATH LIBRARY_OUTPUT_PATH)
 
 if(BUILD_CLIENT AND BUILD_HEADLESS)
 	find_package(SDL2 REQUIRED)
-	# SDL2 exports targets since 2.0.6, but some distributions override config.
-	if(NOT TARGET SDL2::SDL2)
-		add_library(SDL2::SDL2 INTERFACE IMPORTED)
-		set_target_properties(SDL2::SDL2 PROPERTIES
-			INTERFACE_INCLUDE_DIRECTORIES ${SDL2_INCLUDE_DIRS}
-			INTERFACE_LINK_LIBRARIES ${SDL2_LIBRARIES}
-		)
-	endif()
 endif()
 
 if(NOT (BUILD_CLIENT OR BUILD_SERVER))

--- a/src/client/render/core.cpp
+++ b/src/client/render/core.cpp
@@ -90,7 +90,8 @@ void RenderingCore::draw(video::SColor _skycolor, bool _show_hud, bool _show_min
     t->unlock();
 
 	raw_image->drop();
-	delete tex, buffer;
+	delete tex;
+	delete buffer;
         #endif
 }
 


### PR DESCRIPTION
This PR fixes the memleak in the render core by calling `delete` on the `tex` and `buffer` pointers separately. Fixes #25.

## To do

Ready for Review.

## How to test

There should be no warning when the code is compiled.
