### PR TITLE
Fix crash caused by deleting buffer we do not own

### DIFF
--- a/src/client/render/core.cpp
+++ b/src/client/render/core.cpp
@@ -91,7 +91,6 @@ void RenderingCore::draw(video::SColor _skycolor, bool _show_hud, bool _show_min
 
 	raw_image->drop();
 	delete tex;
-	delete buffer;
         #endif
 }
 


### PR DESCRIPTION
This PR fixes #27 by not deleting the buffer in the render core after we get it from the pipeline.

The documentation in pipeline.h,

```cpp
    /**    
     * Create a new object that will be managed by the pipeline    
     *    
     * @tparam T type of the object to be created    
     * @tparam Args types of constructor arguments    
     * @param args constructor arguments    
     * @return T* pointer to the newly created object    
     */    
    template<typename T, typename... Args>
    T *createOwned(Args&&... args) {
        return own(std::make_unique<T>(std::forward<Args>(args)...));
    }
```

and

```cpp
    /**    
     * Create a new object that will be managed by the pipeline    
     *    
     * @tparam T type of the object to be created    
     * @tparam Args types of constructor arguments    
     * @param args constructor arguments    
     * @return T* pointer to the newly created object    
     */    
    template<typename T, typename... Args>
    T *createOwned(Args&&... args) {
        return own(std::make_unique<T>(std::forward<Args>(args)...));
    }
```
makes it clear that the pipeline will delete the buffer. We are not supposed to.

## To do

Ready for Review.

## How to test

Compile and see that ./test_loop.py no longer hangs.
