### PR TITLE
Reorder initializer list in Game

### DIFF
--- a/src/client/game.cpp
+++ b/src/client/game.cpp
@@ -1025,6 +1025,7 @@ private:
 };
 
 Game::Game() :
+	zmqclient(context, zmqpp::socket_type::request),
 	m_chat_log_buf(g_logger),
 	m_game_ui(new GameUI())
 {


### PR DESCRIPTION
Fixes a warning in GCC about the order of initialization not matching the order of the initializer list.

## To do

Ready for Review.

## How to test

Compile with GCC and confirm that the warning is gone.
