### PR TITLE
Add xvfb headless mode and respective flags

### DIFF
--- a/hacking_testing/dumb_client.sh
+++ b/hacking_testing/dumb_client.sh
@@ -1,2 +1,2 @@
 #!/bin/bash
-exec bin/minetest --name me --password whyisthisnecessary --address 0.0.0.0 --port 30000 --go --dumb --client-address "tcp://localhost:5555" --record --noresizing --cursor-image "cursors/mouse_cursor_white_16x16.png"
+exec bin/minetest --name me --password whyisthisnecessary --address 0.0.0.0 --port 30000 --go --dumb --client-address "tcp://localhost:5555" --record --noresizing --cursor-image "cursors/mouse_cursor_white_16x16.png" --headless

--- a/hacking_testing/minetest_env.py
+++ b/hacking_testing/minetest_env.py
@@ -14,7 +14,7 @@ import proto_python.objects_pb2 as pb_objects
 import zmq
 from proto_python.objects_pb2 import KeyType
 
-# Define allowed keys / buttons
+# Define default keys / buttons
 KEY_MAP = {
     "FORWARD": KeyType.FORWARD,
     "BACKWARD": KeyType.BACKWARD,
@@ -37,7 +37,6 @@ KEY_MAP = {
     "SLOT_7": KeyType.SLOT_7,
     "SLOT_8": KeyType.SLOT_8,
     "INVENTORY": KeyType.INVENTORY,
-    "ESC": KeyType.ESC,
 }
 INV_KEY_MAP = {value: key for key, value in KEY_MAP.items()}
 
@@ -121,6 +120,7 @@ def start_minetest_client(
     server_port: int = 30000,
     cursor_img: str = "cursors/mouse_cursor_white_16x16.png",
     client_name: str = "MinetestAgent",
+    xvfb_headless: bool = False,
 ):
     cmd = [
         minetest_path,
@@ -141,6 +141,11 @@ def start_minetest_client(
         "--config",
         config_path,
     ]
+    if xvfb_headless:
+        # hide window
+        cmd.insert(0, "xvfb-run")
+        # don't render to screen
+        cmd.append("--headless")
     if cursor_img:
         cmd.extend(["--cursor-image", cursor_img])
 
@@ -168,8 +173,10 @@ class Minetest(gym.Env):
         seed: Optional[int] = None,
         start_minetest: Optional[bool] = True,
         clientmods: List[str] = [],
+        xvfb_headless: bool = False,
     ):
         # Graphics settings
+        self.xvfb_headless = xvfb_headless
         self.display_size = display_size
         self.fov_y = fov
         self.fov_x = self.fov_y * self.display_size[0] / self.display_size[1]
@@ -309,6 +316,7 @@ class Minetest(gym.Env):
             self.env_port,
             self.server_port,
             self.cursor_image_path,
+            xvfb_headless=self.xvfb_headless,
         )
 
     def _delete_world(self):

--- a/hacking_testing/test_loop.py
+++ b/hacking_testing/test_loop.py
@@ -2,9 +2,10 @@
 from minetest_env import Minetest
 
 start_minetest = True
-render = False
+render = True
+headless = True
 seed = 42
-env = Minetest(seed=seed, start_minetest=start_minetest)
+env = Minetest(seed=seed, start_minetest=start_minetest, xvfb_headless=headless)
 obs = env.reset()
 done = False
 while not done:

--- a/src/client/client.cpp
+++ b/src/client/client.cpp
@@ -1824,7 +1824,12 @@ float Client::getCurRate()
 void Client::makeScreenshot()
 {
 	irr::video::IVideoDriver *driver = m_rendering_engine->get_video_driver();
-	irr::video::IImage* const raw_image = driver->createScreenShot();
+	irr::video::IImage* raw_image;
+	if(m_rendering_engine->headless) {
+		raw_image = m_rendering_engine->get_screenshot();
+	} else {
+		raw_image = driver->createScreenShot();
+	}
 
 	if (!raw_image)
 		return;
@@ -1909,7 +1914,12 @@ float Client::getReward() {
 
 pb_objects::Image Client::getSendableData(core::position2di cursorPosition, bool isMenuActive, irr::video::IImage* cursorImage) {
 	irr::video::IVideoDriver *driver = m_rendering_engine->get_video_driver();
-	irr::video::IImage* const raw_image = driver->createScreenShot();
+	irr::video::IImage* raw_image;
+	if(m_rendering_engine->headless) {
+		raw_image = m_rendering_engine->get_screenshot();
+	} else {
+		raw_image = driver->createScreenShot();
+	}
 
 	if (!raw_image)
 		return pb_objects::Image();
@@ -1934,6 +1944,10 @@ pb_objects::Image Client::getSendableData(core::position2di cursorPosition, bool
 	pb_img.set_height(dim.Height);
 	image->drop();
 	return pb_img;
+}
+
+RenderingEngine* Client::getRenderingEngine() {
+	return m_rendering_engine;
 }
 
 bool Client::shouldShowMinimap() const

--- a/src/client/client.h
+++ b/src/client/client.h
@@ -414,6 +414,7 @@ public:
 	// sends data out
 	float getReward();
 	pb_objects::Image getSendableData(core::position2di cursorPosition, bool isMenuActive, irr::video::IImage* cursorImage);
+	RenderingEngine* getRenderingEngine();
 
 	const Address getServerAddress();
 

--- a/src/client/clientlauncher.cpp
+++ b/src/client/clientlauncher.cpp
@@ -345,6 +345,9 @@ void ClientLauncher::init_args(GameStartData &start_data, const Settings &cmd_ar
 	
 	start_data.resizable = !cmd_args.getFlag("noresizing");
 
+	// headless mode should only be available for the dumb client
+	start_data.headless = dumb && cmd_args.getFlag("headless");
+
 	if (cmd_args.exists("cursor-image"))
 		start_data.cursor_image_path = cmd_args.get("cursor-image");
 }

--- a/src/client/game.cpp
+++ b/src/client/game.cpp
@@ -1198,7 +1198,7 @@ bool Game::startup(bool *kill,
 		}
 	}
 
-	m_rendering_engine->initialize(client, hud);
+	m_rendering_engine->initialize(client, hud, start_data.isHeadless());
 
 	return true;
 }
@@ -1237,7 +1237,7 @@ void Game::run()
 		// send data out
 		std::chrono::steady_clock::time_point begin = std::chrono::steady_clock::now();
 		if(recorder) {
-			pb_objects::Image pb_img = client->getSendableData(input->getMousePos(), isMenuActive, cursorImage);
+			pb_objects::Image pb_img = client->getSendableData(input->getMousePos(), isMenuActive(), cursorImage);
 			recorder->setImage(pb_img);
 			recorder->sendDataOut(isMenuActive(), cursorImage, client, input);
 		}

--- a/src/client/render/core.h
+++ b/src/client/render/core.h
@@ -43,6 +43,8 @@ protected:
 	v2u32 virtual_size { 0, 0 };
 
 	virtual void createPipeline() {}
+	video::IImage *screenshot = nullptr;
+	bool headless;
 
 public:
 	RenderingCore(IrrlichtDevice *device, Client *client, Hud *hud, 
@@ -58,11 +60,12 @@ public:
 
 	// void savetex(video::ITexture *texture, std::string name, video::IVideoDriver* videoDriver);
 
-	void initialize();
+	void initialize(bool headless);
 	void draw(video::SColor _skycolor, bool _show_hud, bool _show_minimap,
 			bool _draw_wield_tool, bool _draw_crosshair);
 
 	v2u32 getVirtualSize() const;
 
 	ShadowRenderer *get_shadow_renderer() { return shadow_renderer; };
+	video::IImage *get_screenshot();
 };

--- a/src/client/render/pipeline.cpp
+++ b/src/client/render/pipeline.cpp
@@ -20,6 +20,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 #include "pipeline.h"
 #include "client/client.h"
 #include "client/hud.h"
+#include "client/renderingengine.h"
 
 #include <vector>
 #include <memory>
@@ -200,11 +201,13 @@ video::ITexture *DynamicSource::getTexture(u8 index)
 }
 
 void ScreenTarget::activate(PipelineContext &context)
-{
-	auto driver = context.device->getVideoDriver();
-	driver->setRenderTarget(nullptr, m_clear, m_clear, context.clear_color);
-	driver->OnResize(size);
-	RenderTarget::activate(context);
+{	
+	if(!context.client->getRenderingEngine()->headless) {
+		auto driver = context.device->getVideoDriver();
+		driver->setRenderTarget(nullptr, m_clear, m_clear, context.clear_color);
+		driver->OnResize(size);
+		RenderTarget::activate(context);
+	}
 }
 
 void DynamicTarget::activate(PipelineContext &context)

--- a/src/client/render/pipeline.h
+++ b/src/client/render/pipeline.h
@@ -409,10 +409,10 @@ public:
 	virtual void setRenderSource(RenderSource *source) override;
 	virtual void setRenderTarget(RenderTarget *target) override;
 	std::vector<RenderStep *> m_pipeline;
+	DynamicTarget m_output;
 private:
 
 	std::vector< std::unique_ptr<RenderPipelineObject> > m_objects;
 	DynamicSource m_input;
-	DynamicTarget m_output;
 	v2f scale { 1.0f, 1.0f };
 };

--- a/src/client/render/plain.cpp
+++ b/src/client/render/plain.cpp
@@ -26,6 +26,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 #include "client/hud.h"
 #include "client/minimap.h"
 #include "client/shadows/dynamicshadowsrender.h"
+#include "client/renderingengine.h"
 
 /// Draw3D pipeline step
 void Draw3D::run(PipelineContext &context)
@@ -146,7 +147,11 @@ void populatePlainPipeline(RenderPipeline *pipeline, Client *client)
 
 	step3D = addUpscaling(pipeline, step3D, downscale_factor);
 
-	step3D->setRenderTarget(pipeline->createOwned<ScreenTarget>());
-
+	if(client->getRenderingEngine()->headless) {
+		step3D->setRenderTarget(&pipeline->m_output);
+		pipeline->addStep(step3D);
+	} else {
+		step3D->setRenderTarget(pipeline->createOwned<ScreenTarget>());
+	}
 	pipeline->addStep<DrawHUD>();
 }

--- a/src/client/renderingengine.cpp
+++ b/src/client/renderingengine.cpp
@@ -185,6 +185,10 @@ void RenderingEngine::cleanupMeshCache()
 	}
 }
 
+irr::video::IImage *RenderingEngine::get_screenshot() {
+	return core->get_screenshot();
+}
+
 bool RenderingEngine::setupTopLevelWindow(const std::string &name)
 {
 	// FIXME: It would make more sense for there to be a switch of some
@@ -540,11 +544,12 @@ std::vector<irr::video::E_DRIVER_TYPE> RenderingEngine::getSupportedVideoDrivers
 	return drivers;
 }
 
-void RenderingEngine::initialize(Client *client, Hud *hud)
+void RenderingEngine::initialize(Client *client, Hud *hud, bool headless)
 {
+	this->headless = headless;
 	const std::string &draw_mode = g_settings->get("3d_mode");
 	core.reset(createRenderingCore(draw_mode, m_device, client, hud));
-	core->initialize();
+	core->initialize(headless);
 }
 
 void RenderingEngine::finalize()

--- a/src/client/renderingengine.h
+++ b/src/client/renderingengine.h
@@ -115,7 +115,7 @@ public:
 	void draw_scene(video::SColor skycolor, bool show_hud,
 			bool show_minimap, bool draw_wield_tool, bool draw_crosshair);
 
-	void initialize(Client *client, Hud *hud);
+	void initialize(Client *client, Hud *hud, bool headless);
 	void finalize();
 
 	bool run()
@@ -131,6 +131,8 @@ public:
 		return nullptr;
 	}
 	static std::vector<irr::video::E_DRIVER_TYPE> getSupportedVideoDrivers();
+	irr::video::IImage *get_screenshot();
+	bool headless;
 
 private:
 	v2u32 _getWindowSize() const;

--- a/src/gameparams.h
+++ b/src/gameparams.h
@@ -47,6 +47,7 @@ struct GameStartData : GameParams
 	bool isSinglePlayer() const { return address.empty() && !local_server; }
 	bool isDumbClient() const { return dumb && !client_address.empty(); }
 	bool isResizable() const { return resizable; }
+	bool isHeadless() const { return headless; }
 
 	std::string name;
 	std::string password;
@@ -57,6 +58,7 @@ struct GameStartData : GameParams
 	std::string client_address;
 	bool record;
 	bool resizable;
+	bool headless;
 	std::string cursor_image_path;
 
 	ELoginRegister allow_login_or_register = ELoginRegister::Any;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -387,6 +387,9 @@ static void set_allowed_options(OptionList *allowed_options)
 			_("Disallow screen resizing."))));
 	allowed_options->insert(std::make_pair("cursor-image", ValueSpec(VALUETYPE_STRING,
 			_("Path to the cursor image file."))));
+	allowed_options->insert(std::make_pair("headless", ValueSpec(VALUETYPE_FLAG,
+			_("Start client in headless mode."))));
+
 
 
 #endif


### PR DESCRIPTION
* add patches that omit rendering to screen, i.e. produce the blank Minetest window
* add runtime flag for headless to Minetest
* add gym env flag to combine this with xvfb to hide window

TODO
- [x] add Xvfb as optional dependency in Readme

This PR is  Ready for Review.

## How to test

```python hacking_testing/test_loop.py```

You should see no Minetest window, but the gym env render window displaying the received frames.
