### PR TITLE
Explictly cast s32 to u32 in comparison

### DIFF
--- a/src/client/dumbhandler.cpp
+++ b/src/client/dumbhandler.cpp
@@ -155,12 +155,12 @@ void DumbClientInputHandler::step(float dtime) {
         // keep mouse pos within screen bounds while GUI is open
         if (mousepos[0] < 0) {
             mousepos[0] = 0;
-        } else if(mousepos[0] >= screenDims[0]) {
+        } else if(static_cast<u32>(mousepos[0]) >= screenDims[0]) {
             mousepos[0] = screenDims[0] - 1;
         }
         if (mousepos[1] < 0) {
             mousepos[1] = 0;
-        } else if (mousepos[1] >= screenDims[1]) {
+        } else if (static_cast<u32>(mousepos[1]) >= screenDims[1]) {
             mousepos[1] = screenDims[1] - 1;
         }
 


### PR DESCRIPTION
Fixes two GCC warnings about comparing an s32 to a u32 with an implicit cast. I've preserved the current behavior, which is to promote the signed integer to unsigned, because it is guaranteed by an earlier condition to be >0. Casting the unsigned screen dimension to signed could theoretically result in a negative dimension, which would move the mouse cursor to the far right of the screen.

## To do

Ready for Review.

## How to test

Compile with GCC and confirm that the warnings are gone.