### PR TITLE
Add terminal state and task mod improvements

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -65,12 +65,14 @@ newworld/
 /mods/minetest/*
 !/mods/minetest/mods_here.txt
 !/mods/mods_here.txt
+!/mods/random_v*/
+!/mods/treechop_v*/
 /worlds
 /world/
 /clientmods/*
 !/clientmods/rewards/
-!/clientmods/random/
-!/clientmods/treechop/
+!/clientmods/random_v*/
+!/clientmods/treechop_v*/
 !/clientmods/mods.conf
 /client/mod_storage/
 

--- a/.gitignore
+++ b/.gitignore
@@ -73,7 +73,6 @@ newworld/
 !/clientmods/rewards/
 !/clientmods/random_v*/
 !/clientmods/treechop_v*/
-!/clientmods/mods.conf
 /client/mod_storage/
 
 ## Configuration/log files
@@ -97,6 +96,7 @@ doc/mkdocs/mkdocs.yml
 
 ## Build files
 build/
+build_headless/
 CMakeFiles
 Makefile
 cmake_install.cmake

--- a/clientmods/mods.conf
+++ b/clientmods/mods.conf
@@ -1,4 +1,6 @@
+load_mod_random_v0 = true
 load_mod_rewards = true
-load_mod_random = false
-load_mod_treechop = false
+load_mod_treechop_v1 = false
+load_mod_random_v1 = false
 load_mod_preview = false
+load_mod_treechop_v0 = false

--- a/clientmods/random/init.lua
+++ b/clientmods/random/init.lua
@@ -1,4 +1,0 @@
--- set random reward at every step
-minetest.register_globalstep(function(dtime)
-    reward = math.random()
-end)

--- a/clientmods/random/mod.conf
+++ b/clientmods/random/mod.conf
@@ -1,1 +1,0 @@
-name = random

--- a/clientmods/random_v0/init.lua
+++ b/clientmods/random_v0/init.lua
@@ -1,0 +1,5 @@
+-- set random reward and terminal values at every step
+minetest.register_globalstep(function(dtime)
+    REWARD = math.random()
+    TERMINAL = math.floor(math.random() + 0.5) == 1
+end)

--- a/clientmods/random_v0/mod.conf
+++ b/clientmods/random_v0/mod.conf
@@ -1,0 +1,1 @@
+name = random_v0

--- a/clientmods/random_v1/init.lua
+++ b/clientmods/random_v1/init.lua
@@ -1,0 +1,13 @@
+-- receive random reward and terminal values from server
+minetest.mod_channel_join("random")
+minetest.register_on_modchannel_message(function(channel_name, sender, message)
+    if channel_name == "random" and sender == "" then
+        -- split the message of format "reward terminal"
+        local split_message = string.gmatch(message, "%S+")
+        local reward = tonumber(split_message())
+        local terminal = split_message()
+        minetest.debug("Receiving random stuff: " .. reward ..  " " .. terminal)
+        REWARD = reward
+        TERMINAL = terminal  == "1"
+    end
+end)

--- a/clientmods/random_v1/init.lua
+++ b/clientmods/random_v1/init.lua
@@ -6,7 +6,6 @@ minetest.register_on_modchannel_message(function(channel_name, sender, message)
         local split_message = string.gmatch(message, "%S+")
         local reward = tonumber(split_message())
         local terminal = split_message()
-        minetest.debug("Receiving random stuff: " .. reward ..  " " .. terminal)
         REWARD = reward
         TERMINAL = terminal  == "1"
     end

--- a/clientmods/random_v1/mod.conf
+++ b/clientmods/random_v1/mod.conf
@@ -1,0 +1,1 @@
+name = random_v1

--- a/clientmods/rewards/init.lua
+++ b/clientmods/rewards/init.lua
@@ -1,8 +1,3 @@
 -- define global reward and terminal variables
 REWARD = 0.0
 TERMINAL = false
-
--- reset reward every step
-minetest.register_globalstep(function(dtime)
-    REWARD = 0.0
-end)

--- a/clientmods/rewards/init.lua
+++ b/clientmods/rewards/init.lua
@@ -1,7 +1,8 @@
--- define global reward variable
-reward = 0.0
+-- define global reward and terminal variables
+REWARD = 0.0
+TERMINAL = false
 
 -- reset reward every step
 minetest.register_globalstep(function(dtime)
-    reward = 0.0
+    REWARD = 0.0
 end)

--- a/clientmods/treechop/init.lua
+++ b/clientmods/treechop/init.lua
@@ -1,6 +1,0 @@
--- reward chopping tree nodes
-minetest.register_on_dignode(function(pos, node)
-    if string.find(node["name"], "tree") then
-        reward = 1.0
-    end
-end)

--- a/clientmods/treechop/mod.conf
+++ b/clientmods/treechop/mod.conf
@@ -1,1 +1,0 @@
-name = treechop

--- a/clientmods/treechop_v0/init.lua
+++ b/clientmods/treechop_v0/init.lua
@@ -1,0 +1,15 @@
+-- task settings
+TREECHOP_GOAL = minetest.settings:get("treechop_goal") or 10
+NUM_CHOPPED_NODES = 0
+
+-- reward chopping tree nodes
+minetest.register_on_dignode(function(pos, node)
+    if string.find(node["name"], "tree") then
+        REWARD = 1.0
+        -- terminate if chopping goal is reached
+        NUM_CHOPPED_NODES = NUM_CHOPPED_NODES + 1
+        if NUM_CHOPPED_NODES >= TREECHOP_GOAL then
+            TERMINAL = true
+        end
+    end
+end)

--- a/clientmods/treechop_v0/mod.conf
+++ b/clientmods/treechop_v0/mod.conf
@@ -1,0 +1,1 @@
+name = treechop_v0

--- a/clientmods/treechop_v0/settingtypes.txt
+++ b/clientmods/treechop_v0/settingtypes.txt
@@ -1,0 +1,3 @@
+#    Number of tree chops required for completing task
+#    Default is 10. At least one chop is required.
+treechop_goal (Tree chop goal) int 10 1 65535

--- a/clientmods/treechop_v1/init.lua
+++ b/clientmods/treechop_v1/init.lua
@@ -1,0 +1,27 @@
+-- task settings
+TREECHOP_GOAL = minetest.settings:get("treechop_goal") or 10
+
+-- reward chopping tree nodes
+minetest.register_on_dignode(function(pos, node)
+    if string.find(node["name"], "tree") then
+        REWARD = 1.0
+    end
+end)
+
+-- terminate task if enough tree items in inventory
+minetest.mod_channel_join("treechop")
+minetest.register_on_modchannel_message(function(channel_name, sender, message)
+    if channel_name == "treechop" and sender == "" then
+        -- split the message of format "player_name num_tree_items"
+        local split_message = string.gmatch(message, "%S+")
+        local player_name = split_message()
+        -- if this client's player dug the a node
+        if player_name == minetest.localplayer:get_name() then
+            -- check if they have enough tree items
+            local num_tree_items = tonumber(split_message())
+            if num_tree_items >= TREECHOP_GOAL then
+                TERMINAL = true
+            end
+        end
+    end
+end)

--- a/clientmods/treechop_v1/mod.conf
+++ b/clientmods/treechop_v1/mod.conf
@@ -1,0 +1,1 @@
+name = treechop_v1

--- a/clientmods/treechop_v1/settingtypes.txt
+++ b/clientmods/treechop_v1/settingtypes.txt
@@ -1,0 +1,3 @@
+#    Number of tree chops required for completing task
+#    Default is 10. At least one chop is required.
+treechop_goal (Tree chop goal) int 10 1 65535

--- a/hacking_testing/data_recorder.py
+++ b/hacking_testing/data_recorder.py
@@ -50,12 +50,12 @@ class DataRecorder:
                     num_attempts = 0
 
                     if self.debug:
-                        _, _, _, _, action = unpack_pb_obs(raw_data)
+                        _, rew, terminal, _, action = unpack_pb_obs(raw_data)
                         action_str = ""
                         for key in action.keys():
                             if key != "MOUSE" and action[key]:
                                 action_str += key + ", "
-                        print(action_str)
+                        print(f"action={action_str}, rew={rew}, T?={terminal}")
 
                     # Write data to new line
                     if not self.debug:

--- a/hacking_testing/minetest.conf
+++ b/hacking_testing/minetest.conf
@@ -2,3 +2,7 @@ default_privs = interact, shout, debug
 developer_mode = false
 enable_client_modding = true
 show_debug = false
+csm_restriction_flags = 0
+enable_mod_channels = true
+
+name = MinetestAgent

--- a/hacking_testing/minetest_env.py
+++ b/hacking_testing/minetest_env.py
@@ -5,7 +5,6 @@ import random
 import shutil
 import subprocess
 import uuid
-from distutils.dir_util import copy_tree
 from typing import Any, Dict, List, Optional, Tuple
 
 import gym

--- a/hacking_testing/record_client.sh
+++ b/hacking_testing/record_client.sh
@@ -1,2 +1,2 @@
 #!/bin/bash
-exec bin/minetest --name me --password whyisthisnecessary --address 0.0.0.0 --port 30000 --go --client-address "tcp://*:5555" --record --noresizing --cursor-image "cursors/mouse_cursor_white_16x16.png"
+exec bin/minetest --name MinetestAgent --password whyisthisnecessary --address 0.0.0.0 --port 30000 --go --client-address "tcp://*:5555" --record --noresizing --cursor-image "cursors/mouse_cursor_white_16x16.png" --config hacking_testing/minetest.conf

--- a/hacking_testing/test_loop.py
+++ b/hacking_testing/test_loop.py
@@ -1,11 +1,14 @@
 #!/usr/bin/env python3
 from minetest_env import Minetest
 
-start_minetest = True
-render = True
-headless = True
-seed = 42
-env = Minetest(seed=seed, start_minetest=start_minetest, xvfb_headless=headless)
+env = Minetest(
+    seed=42,
+    start_minetest=True,
+    xvfb_headless=True,
+    clientmods=["random_v0"],
+)
+
+render = False
 obs = env.reset()
 done = False
 while not done:

--- a/minetest.conf
+++ b/minetest.conf
@@ -1,3 +1,5 @@
 name = MinetestAgent
 menu_last_game = minetest
 enable_client_modding = true
+csm_restriction_flags = 0
+enable_mod_channels = true

--- a/mods/random_v1/init.lua
+++ b/mods/random_v1/init.lua
@@ -1,0 +1,9 @@
+-- create the random mod channel
+modchannel = minetest.mod_channel_join("random")
+
+minetest.register_globalstep(function(dtime)
+   -- broadcast  a random reward and terminal value
+   local reward = math.random()
+   local terminal = math.floor(math.random() + 0.5)
+   modchannel:send_all(tostring(reward) .. " " .. tostring(terminal)) 
+end)

--- a/mods/random_v1/mod.conf
+++ b/mods/random_v1/mod.conf
@@ -1,0 +1,1 @@
+name = random_v1

--- a/mods/treechop_v1/init.lua
+++ b/mods/treechop_v1/init.lua
@@ -1,0 +1,17 @@
+-- create the treechop mod channel
+modchannel = minetest.mod_channel_join("treechop")
+
+minetest.register_on_dignode(function(pos, node, digger)
+   -- count the number of tree items of digging player
+   local num_tree_items = 0
+   local inv = digger:get_inventory()
+   local size = inv:get_size("main")
+   for i = 1, size do
+      local stack = inv:get_stack("main", i)
+      if string.find(stack:get_name(), "tree") then
+            num_tree_items = num_tree_items + stack:get_count()
+      end
+   end
+   -- send the count to clients in format "player_name num_tree_items"
+   modchannel:send_all(digger:get_player_name() .. " " .. tostring(num_tree_items)) 
+end)

--- a/mods/treechop_v1/mod.conf
+++ b/mods/treechop_v1/mod.conf
@@ -1,0 +1,1 @@
+name = treechop_v1

--- a/proto/objects.proto
+++ b/proto/objects.proto
@@ -120,5 +120,6 @@ message Image {
 message Observation {
     Image image = 1;
     float reward = 2;
-    Action action = 3;
+    bool terminal = 3;
+    Action action = 4;
 }

--- a/src/client/client.cpp
+++ b/src/client/client.cpp
@@ -1902,12 +1902,21 @@ float Client::getReward() {
 		ClientScripting *scr = getScript();
 		if(scr) {
 			lua_State *L = scr->getStack();
-			lua_getglobal(L, "REWARD");
+			// read out global REWARD variable
+			lua_getglobal(L, "REWARD"); // push global REWARD value to stack
+			// check if it can be converted to a number
+			if (!lua_isnumber(L, lua_gettop(L)))
+        		errorstream << "`REWARD' should be a number!" << std::endl;
+			// convert to number
 			reward = (float)lua_tonumber(L, lua_gettop(L));
-			lua_pop(L, 1);
+			lua_pop(L, 1); // remove REWARD value from stack
+			// reset global REWARD to zero
+			lua_pushnumber(L, 0.); // push zero to the stack
+			lua_setglobal(L, "REWARD"); // pop zero and assign to REWARD
 		}
-	} catch(...) { // TODO improve error handling
-		warningstream << "No reward mod active!" << std::endl;
+	} catch(LuaError &e) {
+		errorstream << "No reward mod active!" << std::endl;
+		setFatalError(e);
 	}
     return reward;
 }
@@ -1918,12 +1927,19 @@ bool Client::getTerminal() {
 		ClientScripting *scr = getScript();
 		if(scr) {
 			lua_State *L = scr->getStack();
+			// get global TERMINAL variable and push on stack
 			lua_getglobal(L, "TERMINAL");
+			// check whether it can be converted to boolean
+			if (!lua_isboolean(L, lua_gettop(L)))
+        		errorstream << "`TERMINAL' should be a boolean!" << std::endl;
+			// convert to bool
 			terminal = (bool)lua_toboolean(L, lua_gettop(L));
+			// remove from stack
 			lua_pop(L, 1);
 		}
-	} catch(...) { // TODO improve error handling
-		warningstream << "No reward mod active!" << std::endl;
+	} catch(LuaError &e) {
+		errorstream << "No reward mod active!" << std::endl;
+		setFatalError(e);
 	}
     return terminal;
 }

--- a/src/client/client.cpp
+++ b/src/client/client.cpp
@@ -1902,7 +1902,7 @@ float Client::getReward() {
 		ClientScripting *scr = getScript();
 		if(scr) {
 			lua_State *L = scr->getStack();
-			lua_getglobal(L, "reward");
+			lua_getglobal(L, "REWARD");
 			reward = (float)lua_tonumber(L, lua_gettop(L));
 			lua_pop(L, 1);
 		}
@@ -1910,6 +1910,22 @@ float Client::getReward() {
 		warningstream << "No reward mod active!" << std::endl;
 	}
     return reward;
+}
+
+bool Client::getTerminal() {
+	bool terminal = false;
+	try {
+		ClientScripting *scr = getScript();
+		if(scr) {
+			lua_State *L = scr->getStack();
+			lua_getglobal(L, "TERMINAL");
+			terminal = (bool)lua_toboolean(L, lua_gettop(L));
+			lua_pop(L, 1);
+		}
+	} catch(...) { // TODO improve error handling
+		warningstream << "No reward mod active!" << std::endl;
+	}
+    return terminal;
 }
 
 pb_objects::Image Client::getSendableData(core::position2di cursorPosition, bool isMenuActive, irr::video::IImage* cursorImage) {

--- a/src/client/client.h
+++ b/src/client/client.h
@@ -413,6 +413,7 @@ public:
 
 	// sends data out
 	float getReward();
+	bool getTerminal();
 	pb_objects::Image getSendableData(core::position2di cursorPosition, bool isMenuActive, irr::video::IImage* cursorImage);
 	RenderingEngine* getRenderingEngine();
 

--- a/src/client/recorder.cpp
+++ b/src/client/recorder.cpp
@@ -32,6 +32,7 @@ void Recorder::setImage(pb_objects::Image & img) {
 void Recorder::sendDataOut(bool isMenuActive, irr::video::IImage* cursorImage, Client *client, InputHandler *input) {
     pb_objects::Observation obsToSend;
     obsToSend.set_reward(client->getReward());
+    obsToSend.set_terminal(client->getTerminal());
     obsToSend.set_allocated_image(&imgToSend);
     obsToSend.set_allocated_action(&actionToSend);
     std::string msg = obsToSend.SerializeAsString();

--- a/src/client/render/core.cpp
+++ b/src/client/render/core.cpp
@@ -23,6 +23,8 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 #include "client/shadows/dynamicshadowsrender.h"
 #include "settings.h"
 #include <iostream>
+#include "client/renderingengine.h"
+#include "client/client.h"
 
 RenderingCore::RenderingCore(IrrlichtDevice *_device, Client *_client, Hud *_hud, 
 		ShadowRenderer *_shadow_renderer, RenderPipeline *_pipeline, v2f _virtual_size_scale)
@@ -37,9 +39,8 @@ RenderingCore::~RenderingCore()
 	delete shadow_renderer;
 }
 
-void RenderingCore::initialize(bool headless)
+void RenderingCore::initialize()
 {
-	this->headless = headless;
 	if (shadow_renderer)
 		pipeline->addStep<RenderShadowMapStep>();
 
@@ -58,7 +59,7 @@ void RenderingCore::draw(video::SColor _skycolor, bool _show_hud, bool _show_min
 	context.show_hud = _show_hud;
 	context.show_minimap = _show_minimap;
 
-    if(headless) {
+    if(client->getRenderingEngine()->headless) {
 		TextureBuffer *buffer = pipeline->createOwned<TextureBuffer>();
 		buffer->setTexture(0, v2f(1.0f, 1.0f), "idk_lol", video::ECF_R8G8B8);
 		auto tex = new TextureBufferOutput(buffer, 0);

--- a/src/client/render/core.h
+++ b/src/client/render/core.h
@@ -44,7 +44,6 @@ protected:
 
 	virtual void createPipeline() {}
 	video::IImage *screenshot = nullptr;
-	bool headless;
 
 public:
 	RenderingCore(IrrlichtDevice *device, Client *client, Hud *hud, 
@@ -58,9 +57,7 @@ public:
 	RenderingCore &operator=(RenderingCore &&) = delete;
 
 
-	// void savetex(video::ITexture *texture, std::string name, video::IVideoDriver* videoDriver);
-
-	void initialize(bool headless);
+	void initialize();
 	void draw(video::SColor _skycolor, bool _show_hud, bool _show_minimap,
 			bool _draw_wield_tool, bool _draw_crosshair);
 

--- a/src/client/renderingengine.cpp
+++ b/src/client/renderingengine.cpp
@@ -549,7 +549,7 @@ void RenderingEngine::initialize(Client *client, Hud *hud, bool headless)
 	this->headless = headless;
 	const std::string &draw_mode = g_settings->get("3d_mode");
 	core.reset(createRenderingCore(draw_mode, m_device, client, hud));
-	core->initialize(headless);
+	core->initialize();
 }
 
 void RenderingEngine::finalize()


### PR DESCRIPTION
* Add terminal flag as Lua global variable and in protobuf observation
* Update mods to set terminal state 
  * two different treechop versions: in version 0 there is a number of required chops for completing task (`treechop_goal`), in version 1 the player has to have a certain amount of tree items in the inventory (note this version uses a mod channel, which requires a server-side mod to read out a player's inventory)
* adds support for server mods and mod settings (like the `treechop_goal`) in minetest gym env  

## To do
 Ready for Review.

## How to test

You can test different task mods by supplying them to `Minetest` constructor, e.g. `clientmods=["random_v0"]`.
Then run:
`python hacking_testing/test_loop.py`
It should end after a very short time, because at each step a coin is flipped whether the task is complete.
You can also test the treechop mods when using the recording client. Run `server.sh`, `record_client.sh` and `data_recorder.py`. 
The data recorder should log your actions, rewards and whether you have reached the terminal state yet.