### PR TITLE
Cmake sdl2 target fix

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -95,6 +95,7 @@ doc/mkdocs/mkdocs.yml
 
 ## Build files
 build/
+build_headless/
 CMakeFiles
 Makefile
 cmake_install.cmake

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -70,6 +70,19 @@ set(ENABLE_UPDATE_CHECKER (NOT ${DEVELOPMENT_BUILD}) CACHE BOOL
 set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} "${CMAKE_SOURCE_DIR}/cmake/Modules/")
 
 
+
+if(BUILD_CLIENT AND BUILD_HEADLESS)
+	find_package(SDL2 REQUIRED NO_DEFAULT_PATH)
+	# SDL2 exports targets since 2.0.6, but some distributions override config.
+	if(NOT TARGET SDL2::SDL2)
+		add_library(SDL2::SDL2 INTERFACE IMPORTED)
+		set_target_properties(SDL2::SDL2 PROPERTIES
+			INTERFACE_INCLUDE_DIRECTORIES ${SDL2_INCLUDE_DIRS}
+			INTERFACE_LINK_LIBRARIES ${SDL2_LIBRARIES}
+		)
+	endif()
+endif()
+
 set(IRRLICHTMT_BUILD_DIR "" CACHE PATH "Path to IrrlichtMt build directory.")
 if(NOT "${IRRLICHTMT_BUILD_DIR}" STREQUAL "")
 	find_package(IrrlichtMt QUIET

--- a/hacking_testing/minetest_env.py
+++ b/hacking_testing/minetest_env.py
@@ -345,6 +345,7 @@ class Minetest(gym.Env):
             config_file.write("mute_sound = true\n")
             config_file.write("show_debug = false\n")
             config_file.write("enable_client_modding = true\n")
+            config_file.write("video_driver = null\n")
 
             # Set display size
             config_file.write(f"screen_w = {self.display_size[0]}\n")

--- a/hacking_testing/minetest_env.py
+++ b/hacking_testing/minetest_env.py
@@ -346,6 +346,7 @@ class Minetest(gym.Env):
             config_file.write("show_debug = false\n")
             config_file.write("enable_client_modding = true\n")
             config_file.write("video_driver = null\n")
+            config_file.write("enable_shaders = false\n")
 
             # Set display size
             config_file.write(f"screen_w = {self.display_size[0]}\n")


### PR DESCRIPTION
Fix a SDL2 target not found error in Cmake configure step

- Goal of the PR
- How does the PR work?
- Does it resolve any reported issue?
- Does this relate to a goal in [the roadmap](../doc/direction.md)?
- If not a bug fix, why is this PR needed? What usecases does it solve?

## To do

This PR is a Work in Progress / Ready for Review.
<!-- ^ delete one -->

- [ ] List
- [ ] Things
- [ ] To do

## How to test

<!-- Example code or instructions -->
