### PR TITLE
Fix protobuf compiler

### DIFF
--- a/scripts/compile_proto.sh
+++ b/scripts/compile_proto.sh
@@ -1,2 +1,2 @@
 #!/bin/bash
-protoc -I=../proto/ --python_out=../minetests/proto --cpp_out=../src ../proto/*.proto
+protoc -I=../proto/ --python_out=../minetester/proto --cpp_out=../src ../proto/*.proto


### PR DESCRIPTION
The path in the protobuf script wasn't changed after the rename from `minetests` to `minetester`. This causes protobuf compilation to fail silently.
