### PR TITLE
Fix seed and empty frame sending

### DIFF
--- a/minetester/minetest_env.py
+++ b/minetester/minetest_env.py
@@ -260,19 +260,19 @@ class Minetest(gym.Env):
             config_file.write(f"fov = {self.fov_y}\n")
 
             # Seed the map generator
-            if self.seed:
-                config_file.write(f"fixed_map_seed = {self.seed}\n")
+            if self.the_seed:
+                config_file.write(f"fixed_map_seed = {self.the_seed}\n")
 
             # Set from custom config dict
             for key, value in self.config_dict.items():
                 config_file.write(f"{key} = {value}\n")
 
     def seed(self, seed: int):
-        self.seed = seed
+        self.the_seed = seed
 
         # Create UUID from seed
         rnd = random.Random()
-        rnd.seed(self.seed)
+        rnd.seed(self.the_seed)
         self.unique_env_id = str(uuid.UUID(int=rnd.getrandbits(128), version=4))
 
         # If not set manually, world and config paths are based on UUID

--- a/src/client/game.cpp
+++ b/src/client/game.cpp
@@ -1229,14 +1229,14 @@ void Game::run()
 	irr::core::dimension2d<u32> previous_screen_size(g_settings->getU16("screen_w"),
 		g_settings->getU16("screen_h"));
 
-	while (m_rendering_engine->run()
-			&& !(*kill || g_gamecallback->shutdown_requested
-			|| (server && server->isShutdownRequested()))) {
-		
+	bool firstIter = true;
+	while (m_rendering_engine->run() &&
+			!(*kill || g_gamecallback->shutdown_requested ||
+					(server && server->isShutdownRequested()))) {
 
 		// send data out
 		std::chrono::steady_clock::time_point begin = std::chrono::steady_clock::now();
-		if(recorder) {
+		if(recorder && !firstIter) {
 			pb_objects::Image pb_img = client->getSendableData(input->getMousePos(), isMenuActive(), cursorImage);
 			recorder->setImage(pb_img);
 			recorder->sendDataOut(isMenuActive(), cursorImage, client, input);
@@ -1279,7 +1279,13 @@ void Game::run()
 
 
 		updateProfilers(stats, draw_times, dtime);
-		processUserInput(dtime);
+		if(recorder && !firstIter) {
+			processUserInput(dtime);
+			pb_objects::Action inputState = input->getLastAction();
+			recorder->setAction(inputState);
+		} else if(recorder == nullptr) {
+			processUserInput(dtime);
+		}
 		// Update camera before player movement to avoid camera lag of one frame
 		updateCameraDirection(&cam_view_target, dtime);
 		cam_view.camera_yaw += (cam_view_target.camera_yaw -
@@ -1316,7 +1322,7 @@ void Game::run()
 		if (m_does_lost_focus_pause_game && !device->isWindowFocused() && !isMenuActive()) {
 			showPauseMenu();
 		}
-
+		firstIter = false;
 	}
 }
 
@@ -2037,13 +2043,6 @@ void Game::processUserInput(f32 dtime)
 
 	// Input handler step() (used by the random input generator)
 	input->step(dtime);
-
-	if(recorder) {
-		// need to get input state before key input is processed
-		// because calls to wasKeyDown reset the isKeyDown state
-		pb_objects::Action inputState = input->getLastAction();
-		recorder->setAction(inputState);
-	}
 
 #ifdef __ANDROID__
 	auto formspec = m_game_ui->getFormspecGUI();


### PR DESCRIPTION
fixes two bugs
* `seed` in minetest env was both method and attribute
* in headless mode the first frame sent is empty. The fix skips that frame in the game loop by applying the noop action

Ready for Review.

## How to test

Run `test_loop.py` with `xvfb_headless=True` and print the obs shape. It should receive frames of the display size.
