### PR TITLE
Fix memory leak in headless mode

### DIFF
--- a/src/client/render/core.cpp
+++ b/src/client/render/core.cpp
@@ -31,6 +31,10 @@ RenderingCore::RenderingCore(IrrlichtDevice *_device, Client *_client, Hud *_hud
 	: device(_device), client(_client), hud(_hud), shadow_renderer(_shadow_renderer), 
 	pipeline(_pipeline), virtual_size_scale(_virtual_size_scale)
 {
+	if (client->getRenderingEngine()->headless) {
+		m_buffer = pipeline->createOwned<TextureBuffer>();
+		m_buffer->setTexture(0, v2f(1.0f, 1.0f), "idk_lol", video::ECF_R8G8B8);
+	}
 }
 
 RenderingCore::~RenderingCore()
@@ -60,9 +64,7 @@ void RenderingCore::draw(video::SColor _skycolor, bool _show_hud, bool _show_min
 	context.show_minimap = _show_minimap;
 
     if(client->getRenderingEngine()->headless) {
-		TextureBuffer *buffer = pipeline->createOwned<TextureBuffer>();
-		buffer->setTexture(0, v2f(1.0f, 1.0f), "idk_lol", video::ECF_R8G8B8);
-		auto tex = new TextureBufferOutput(buffer, 0);
+		auto tex = new TextureBufferOutput(m_buffer, 0);
 		pipeline->setRenderTarget(tex);
 
 
@@ -72,8 +74,7 @@ void RenderingCore::draw(video::SColor _skycolor, bool _show_hud, bool _show_min
 		auto t = tex->buffer->getTexture(0);
 		auto raw_image = device->getVideoDriver()->createImageFromData(
 			t->getColorFormat(),
-			device->getVideoDriver()->getScreenSize(),
-			// t->getSize(),
+			screensize,
 			t->lock(irr::video::E_TEXTURE_LOCK_MODE::ETLM_READ_ONLY),
 			false  //copy mem
 			);
@@ -81,8 +82,7 @@ void RenderingCore::draw(video::SColor _skycolor, bool _show_hud, bool _show_min
 			screenshot->drop();
 		screenshot =
 				device->getVideoDriver()->createImage(video::ECF_R8G8B8,
-				device->getVideoDriver()->getScreenSize()
-				//  raw_image->getDimension()
+				screensize
 				);
 		raw_image->copyTo(screenshot);
 		t->unlock();

--- a/src/client/render/core.h
+++ b/src/client/render/core.h
@@ -20,6 +20,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 
 #pragma once
 #include "irrlichttypes_extrabloated.h"
+#include "pipeline.h"
 
 class ShadowRenderer;
 class Camera;
@@ -44,6 +45,7 @@ protected:
 
 	virtual void createPipeline() {}
 	video::IImage *screenshot = nullptr;
+	TextureBuffer* m_buffer = nullptr;
 
 public:
 	RenderingCore(IrrlichtDevice *device, Client *client, Hud *hud, 


### PR DESCRIPTION
Fixes a memory leak in headless mode by using the same TextureBuffer object every iteration.

Ready for Review.

## How to test

check that system memory stays roughly constant when running minetest dumbclient in headless mode
