### PR TITLE
Add treechop task with shaping rewards

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -68,12 +68,14 @@ newworld/
 !/mods/mods_here.txt
 !/mods/random_v*/
 !/mods/treechop_v*/
+!/mods/treechop_shaped_v*/
 /worlds
 /world/
 /clientmods/*
 !/clientmods/rewards/
 !/clientmods/random_v*/
 !/clientmods/treechop_v*/
+!/clientmods/treechop_shaped_v*/
 /client/mod_storage/
 
 ## Configuration/log files

--- a/clientmods/mods.conf
+++ b/clientmods/mods.conf
@@ -4,3 +4,4 @@ load_mod_treechop_v1 = false
 load_mod_random_v1 = false
 load_mod_preview = false
 load_mod_treechop_v0 = false
+load_mod_treechop_shaped_v0 = false

--- a/clientmods/treechop_shaped_v0/init.lua
+++ b/clientmods/treechop_shaped_v0/init.lua
@@ -1,0 +1,62 @@
+-- task settings
+TREECHOP_GOAL = minetest.settings:get("treechop_goal") or 10
+MAX_TREE_DISTANCE = minetest.settings:get("max_tree_distance") or 0
+NUM_CHOPPED_NODES = 0
+
+-- reward chopping tree nodes
+minetest.register_on_dignode(function(pos, node)
+    if string.find(node["name"], "tree") then
+        REWARD = REWARD + 1.0
+        -- terminate if chopping goal is reached
+        NUM_CHOPPED_NODES = NUM_CHOPPED_NODES + 1
+        if NUM_CHOPPED_NODES >= TREECHOP_GOAL then
+            TERMINAL = true
+        end
+    end
+end)
+
+minetest.register_globalstep(function(dtime)
+    -- reward looking at trees
+    local player_pos = core.localplayer:get_pos()
+    local cam_pos = core.camera:get_pos()
+	local pos2 = vector.add(cam_pos, vector.multiply(core.camera:get_look_dir(), 30))
+	local rc = core.raycast(cam_pos, pos2, false, false)
+    local thing = rc:next()
+    while thing do
+        if thing.type == "node" then
+            local pos = thing.under
+            local node = minetest.get_node_or_nil(pos)
+            local node_name = node.name
+            if string.find(node_name, "tree") then
+                --minetest.debug("Looking at a tree!")
+                REWARD = REWARD + 0.01
+            end
+        end
+        thing = rc:next()
+    end
+
+    if MAX_TREE_DISTANCE > 0 then
+        -- rewards being closer to tree nodes
+        local tree_pos = minetest.find_node_near(
+            player_pos,
+            MAX_TREE_DISTANCE,
+            -- TODO why does group:tree not work for all tree nodes?
+            {"group:tree", "default:tree", "default:acacia_tree", "default:jungle_tree"},
+            true
+        )
+        local dist = MAX_TREE_DISTANCE 
+        if tree_pos ~= nil then
+            --minetest.debug("Tree within range!")
+            dist = vector.distance(tree_pos, player_pos)
+        end
+        REWARD = REWARD - 0.01 * dist
+    end
+end)
+
+minetest.register_on_punchnode(function(pos, node)
+    -- reward punching trees
+    if string.find(node["name"], "tree") then
+        --minetest.debug("Punched a tree!")
+        REWARD = REWARD + 0.1
+    end
+end)

--- a/clientmods/treechop_shaped_v0/init.lua
+++ b/clientmods/treechop_shaped_v0/init.lua
@@ -41,7 +41,7 @@ minetest.register_globalstep(function(dtime)
             player_pos,
             MAX_TREE_DISTANCE,
             -- TODO why does group:tree not work for all tree nodes?
-            {"group:tree", "default:tree", "default:acacia_tree", "default:jungle_tree"},
+            {"group:tree", "default:tree", "default:acacia_tree", "default:jungle_tree", "default:pine_tree", "default:aspen_tree"},
             true
         )
         local dist = MAX_TREE_DISTANCE 
@@ -57,6 +57,6 @@ minetest.register_on_punchnode(function(pos, node)
     -- reward punching trees
     if string.find(node["name"], "tree") then
         --minetest.debug("Punched a tree!")
-        REWARD = REWARD + 0.1
+        REWARD = REWARD + 0.01
     end
 end)

--- a/clientmods/treechop_shaped_v0/mod.conf
+++ b/clientmods/treechop_shaped_v0/mod.conf
@@ -1,0 +1,1 @@
+name = treechop_shaped_v0

--- a/clientmods/treechop_shaped_v0/settingtypes.txt
+++ b/clientmods/treechop_shaped_v0/settingtypes.txt
@@ -1,0 +1,4 @@
+#    Number of tree chops required for completing task
+#    Default is 10. At least one chop is required.
+treechop_goal (Tree chop goal) int 10 1 65535
+max_tree_distance (Maximum distance to tree nodes for proximity reward) int 0 0 10


### PR DESCRIPTION
Adds a treechop mod with shaped rewards that in addition
- reward looking at tree nodes
- reward punching (not only breaking) tree nodes
- (optional) penalize more distance to tree nodes within a given range 

Helps with https://github.com/EleutherAI/minetest-baselines/issues/2

Ready for Review.

## How to test

Run with `clientmods=["treechop_shaped-v0"]` or activate manually and `clientmods/mods.conf`
