### PR TITLE
Improve Xvfb usage

### DIFF
--- a/minetester/minetest_env.py
+++ b/minetester/minetest_env.py
@@ -148,7 +148,7 @@ class Minetest(gym.Env):
         self.start_xvfb = start_xvfb and self.headless
         self.xserver_process = None
         if self.start_xvfb:
-            self.x_display = x_display or self.default_display + 2
+            self.x_display = x_display or self.default_display + 4
             self.xserver_process = start_xserver(self.x_display, self.display_size)
 
     def _enable_clientmods(self):

--- a/minetester/minetest_env.py
+++ b/minetester/minetest_env.py
@@ -12,7 +12,7 @@ import numpy as np
 import psutil
 import zmq
 from minetester.utils import (KEY_MAP, pack_pb_action, start_minetest_client,
-                              start_minetest_server, unpack_pb_obs)
+                              start_minetest_server, unpack_pb_obs, start_xserver)
 
 
 class Minetest(gym.Env):
@@ -34,13 +34,18 @@ class Minetest(gym.Env):
         clientmods: List[str] = [],
         servermods: List[str] = [],
         config_dict: Dict[str, Any] = {},
-        xvfb_headless: bool = False,
+        headless: bool = False,
+        start_xvfb: bool = False,
+        x_display: Optional[int] = None,
     ):
+        self.unique_env_id = str(uuid.uuid4())
+
         # Graphics settings
-        self.xvfb_headless = xvfb_headless
+        self.headless = headless
         self.display_size = display_size
         self.fov_y = fov
         self.fov_x = self.fov_y * self.display_size[0] / self.display_size[1]
+
         # Define action and observation space
         self.max_mouse_move_x = self.display_size[0]
         self.max_mouse_move_y = self.display_size[1]
@@ -82,11 +87,14 @@ class Minetest(gym.Env):
                 "mouse_cursor_white_16x16.png",
             )
 
-        # Regenerate and clean world if no custom world provided
+        # Regenerate and clean world and config if no custom ones provided
         self.reset_world = self.world_dir is None
-
-        # Clean config if no custom config provided
         self.clean_config = self.config_path is None
+        # If no custom world / config provided set folder / path based on UUID
+        if self.world_dir is None:
+            self.world_dir = os.path.join(self.root_dir, self.unique_env_id)
+        if self.config_path is None:
+            self.config_path = os.path.join(self.root_dir, f"{self.unique_env_id}.conf")
 
         # Whether to start minetest server and client
         self.start_minetest = start_minetest
@@ -109,7 +117,6 @@ class Minetest(gym.Env):
         self.render_img = None
 
         # Seed the environment
-        self.unique_env_id = str(uuid.uuid4())  # fallback UUID when no seed is provided
         if seed is not None:
             self.seed(seed)
 
@@ -132,6 +139,17 @@ class Minetest(gym.Env):
         # Write minetest.conf
         self.config_dict = config_dict
         self._write_config()
+
+        # Start X server virtual frame buffer
+        self.default_display = x_display or 0
+        if "DISPLAY" in os.environ:
+            self.default_display = int(os.environ["DISPLAY"].split(":")[1])
+        self.x_display = x_display or self.default_display
+        self.start_xvfb = start_xvfb and self.headless
+        self.xserver_process = None
+        if self.start_xvfb:
+            self.x_display = x_display or self.default_display + 2
+            self.xserver_process = start_xserver(self.x_display, self.display_size)
 
     def _enable_clientmods(self):
         clientmods_folder = os.path.realpath(
@@ -159,7 +177,6 @@ class Minetest(gym.Env):
         if not os.path.exists(servermods_folder):
             raise RuntimeError(f"Server mods must be located at {servermods_folder}!")
         # Create world_dir/worldmods folder
-        self._check_world_dir()
         worldmods_folder = os.path.join(self.world_dir, "worldmods")
         os.makedirs(worldmods_folder, exist_ok=True)
         # Copy server mods to world_dir/worldmods
@@ -189,10 +206,13 @@ class Minetest(gym.Env):
             f"{{}}_{reset_timestamp}_{self.unique_env_id}.log",
         )
 
-        # (Re)start Minetest server
+        # Close Mintest processes
         if self.server_process:
             self.server_process.kill()
+        if self.client_process:
+            self.client_process.kill()
 
+        # (Re)start Minetest server
         self.server_process = start_minetest_server(
             self.minetest_executable,
             self.config_path,
@@ -202,13 +222,7 @@ class Minetest(gym.Env):
         )
 
         # (Re)start Minetest client
-        if self.client_process:
-            self.client_process.kill()
-            if self.xvfb_headless:
-                # kill running xvfb processes
-                for proc in psutil.process_iter():
-                    if proc.name() in ["Xvfb"]:
-                        proc.kill()
+        os.environ["DISPLAY"] = f":{self.x_display}"
         self.client_process = start_minetest_client(
             self.minetest_executable,
             self.config_path,
@@ -216,30 +230,15 @@ class Minetest(gym.Env):
             self.env_port,
             self.server_port,
             self.cursor_image_path,
-            xvfb_headless=self.xvfb_headless,
+            headless=self.headless,
         )
-    
-    def _check_world_dir(self):
-        if self.world_dir is None:
-            raise RuntimeError(
-                "World directory was not set. Please, provide a world directory "
-                "in the constructor or seed the environment!",
-            )
+        os.environ["DISPLAY"] = f":{self.default_display}"
 
     def _delete_world(self):
-        self._check_world_dir()
         if os.path.exists(self.world_dir):
             shutil.rmtree(self.world_dir)
-    
-    def _check_config_path(self):
-        if self.config_path is None:
-            raise RuntimeError(
-                "Minetest config path was not set. Please, provide a config path "
-                "in the constructor or seed the environment!",
-            )
 
     def _delete_config(self):
-        self._check_config_path()
         if os.path.exists(self.config_path):
             os.remove(self.config_path)
 
@@ -269,17 +268,6 @@ class Minetest(gym.Env):
 
     def seed(self, seed: int):
         self.the_seed = seed
-
-        # Create UUID from seed
-        rnd = random.Random()
-        rnd.seed(self.the_seed)
-        self.unique_env_id = str(uuid.UUID(int=rnd.getrandbits(128), version=4))
-
-        # If not set manually, world and config paths are based on UUID
-        if self.world_dir is None:
-            self.world_dir = os.path.join(self.root_dir, self.unique_env_id)
-        if self.config_path is None:
-            self.config_path = os.path.join(self.root_dir, f"{self.unique_env_id}.conf")
 
     def reset(self):
         if self.start_minetest:
@@ -360,11 +348,8 @@ class Minetest(gym.Env):
             self.client_process.kill()
         if self.server_process is not None:
             self.server_process.kill()
-        if self.xvfb_headless:
-            # kill remaining xvfb and minetest processes
-            for proc in psutil.process_iter():
-                if proc.name() in ["Xvfb", "minetest"]:
-                    proc.kill()
+        if self.xserver_process is not None:
+            self.xserver_process.terminate()
         if self.reset_world:
             self._delete_world()
         if self.clean_config:

--- a/minetester/scripts/test_loop.py
+++ b/minetester/scripts/test_loop.py
@@ -16,7 +16,6 @@ while not done:
     try:
         action = env.action_space.sample()
         obs, rew, done, info = env.step(action)
-        print(obs.shape)
         if render:
             env.render()
     except KeyboardInterrupt:

--- a/minetester/scripts/test_loop.py
+++ b/minetester/scripts/test_loop.py
@@ -4,7 +4,8 @@ from minetester import Minetest
 env = Minetest(
     seed=42,
     start_minetest=True,
-    xvfb_headless=True,
+    headless=True,
+    start_xvfb=True,
     clientmods=["random_v0"],
 )
 
@@ -15,6 +16,7 @@ while not done:
     try:
         action = env.action_space.sample()
         obs, rew, done, info = env.step(action)
+        print(obs.shape)
         if render:
             env.render()
     except KeyboardInterrupt:

--- a/minetester/scripts/test_loop_parallel.py
+++ b/minetester/scripts/test_loop_parallel.py
@@ -34,7 +34,7 @@ if __name__ == "__main__":
     # Env settings
     seed = 42
     max_steps = 100
-    x_display = 2
+    x_display = 4
     env_kwargs = {
         "display_size": (600, 400),
         "fov": 72,

--- a/minetester/scripts/test_loop_parallel.py
+++ b/minetester/scripts/test_loop_parallel.py
@@ -1,7 +1,9 @@
+import random
 from typing import Any, Dict, Optional
 
 from gym.wrappers import TimeLimit
 from minetester import Minetest
+from minetester.utils import start_xserver
 from stable_baselines3.common.vec_env import DummyVecEnv, SubprocVecEnv
 
 if __name__ == "__main__":
@@ -24,7 +26,7 @@ if __name__ == "__main__":
                 seed=seed + rank,
                 **env_kwargs,
             )
-            env = TimeLimit(env, max_episode_steps=max_steps)
+            env = TimeLimit(env, max_episode_steps=int(max_steps * random.random()))
             return env
 
         return _init
@@ -32,7 +34,13 @@ if __name__ == "__main__":
     # Env settings
     seed = 42
     max_steps = 100
-    env_kwargs = {"display_size": (600, 400), "fov": 72}
+    x_display = 2
+    env_kwargs = {
+        "display_size": (600, 400),
+        "fov": 72,
+        "headless": True,
+        "x_display": x_display
+    }
 
     # Create a vectorized environment
     num_envs = 2  # Number of envs to use (<= number of avail. cpus)
@@ -44,14 +52,20 @@ if __name__ == "__main__":
         ],
     )
 
+    # Start X server
+    xserver = start_xserver(x_display)
+
     # Start loop
-    render = False
+    render = True
     obs = venv.reset()
     done = [False] * num_envs
-    while sum(done) != num_envs:
+    step = 0
+    while step < max_steps:
         print(f"Elapsed steps: {venv.get_attr('_elapsed_steps')}")
         actions = [venv.action_space.sample() for _ in range(num_envs)]
         obs, rew, done, info = venv.step(actions)
         if render:
             venv.render()
+        step += 1
     venv.close()
+    xserver.terminate()

--- a/minetester/utils.py
+++ b/minetester/utils.py
@@ -1,5 +1,5 @@
 import subprocess
-from typing import Any, Dict
+from typing import Any, Dict, Tuple
 
 import numpy as np
 from minetester.proto import objects_pb2 as pb_objects
@@ -111,7 +111,7 @@ def start_minetest_client(
     server_port: int = 30000,
     cursor_img: str = "cursors/mouse_cursor_white_16x16.png",
     client_name: str = "MinetestAgent",
-    xvfb_headless: bool = False,
+    headless: bool = False,
 ):
     cmd = [
         minetest_path,
@@ -132,10 +132,7 @@ def start_minetest_client(
         "--config",
         config_path,
     ]
-    if xvfb_headless:
-        # hide window
-        cmd.insert(0, "-a")  # allow restarts
-        cmd.insert(0, "xvfb-run")
+    if headless:
         # don't render to screen
         cmd.append("--headless")
     if cursor_img:
@@ -146,3 +143,19 @@ def start_minetest_client(
     with open(stdout_file, "w") as out, open(stderr_file, "w") as err:
         client_process = subprocess.Popen(cmd, stdout=out, stderr=err)
     return client_process
+
+
+def start_xserver(
+    display_idx: int = 1,
+    display_size: Tuple[int, int] = (1024, 600),
+    display_depth: int = 24,
+):
+    cmd = [
+        "Xvfb",
+        f":{display_idx}",
+        "-screen",
+        "0",  # screennum param
+        f"{display_size[0]}x{display_size[1]}x{display_depth}",
+    ]
+    xserver_process = subprocess.Popen(cmd)
+    return xserver_process


### PR DESCRIPTION
* start a single Xvfb process for the lifetime of the environment
* don't kill all minetest / Xvfb processes on reset()
* allow passing a display variable of existing Xvfb process
* add utility for starting Xvfb process
other change:
* don't use seed-dependent UUID anymore (useful for parallel envs with equal seeds)

Helps with training agents in parallel envs, e.g. https://github.com/EleutherAI/minetest-baselines/issues/1 and https://github.com/EleutherAI/minetest-baselines/issues/2

Ready for Review.

## How to test

Run scripts in `minetester/scripts`.
Check that there are no minetest/xvfb processes remaining afterwards.
