### PR TITLE
Update the protobuf version in setup.py

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 EleutherAI Alignment Minetest
 =============================
-This is a fork of the Minetest Voxel Engine, designed to support an OAI gym like environment. The library supports 
+This is a fork of the Minetest Voxel Engine, designed to support an OAI gym like environment. The library supports
 
 Modes of Operation
 ------------------
@@ -14,7 +14,7 @@ The model provides 4 modes of operation for players and agents
 Minetester
 ==========
 Minetester is the Python package that exposes Minetest environments via the `gym(nasium)` interface.
-After building the minetest executable you can install it with:
+After [building the minetest executable](https://github.com/EleutherAI/minetest/blob/develop/build_instructions.txt) you can install it with:
 ```
 pip install -e .
 ```

--- a/build_instructions.txt
+++ b/build_instructions.txt
@@ -1,4 +1,4 @@
-1. Install prereqs 
+1. Install prereqs
   1. sudo apt-get install xvfb g++ make libzmq3-dev libtool pkg-config build-essential autoconf automake libc6-dev cmake libpng-dev libjpeg-dev libxi-dev libgl1-mesa-dev libsqlite3-dev libogg-dev libvorbis-dev libopenal-dev libcurl4-gnutls-dev libfreetype6-dev zlib1g-dev libgmp-dev libjsoncpp-dev libzstd-dev libluajit-5.1-dev protobuf-compiler
 
 2. Build SDL2
@@ -33,17 +33,14 @@
 6. Build minetest
   1. cd into minetest
   2. either run
-     cmake . -DRUN_IN_PLACE=TRUE -DBUILD_HEADLESS=1 -DSDL2_DIR=<path to SDL repo>/SDL/build/lib/cmake/SDL2/ 
-     or 
+     cmake . -DRUN_IN_PLACE=TRUE -DBUILD_HEADLESS=1 -DSDL2_DIR=<path to SDL repo>/SDL/build/lib/cmake/SDL2/
+     or
      cmake . -DRUN_IN_PLACE=TRUE -DBUILD_HEADLESS=0 -DSDL2_DIR=
   3. run make -j$(nproc)
 
-7. setup python 
-  1. create a new python conda env or venv (tested with python3.9)
-  2. pip install gym matplotlib protobuf==3.20.1 psutil zmq
+7. setup python
+  1. create and activate a new python conda env or venv (tested with python3.9)
+  2. pip install gym matplotlib protobuf==3.20.1 psutil zmq -e ./minetest
   3. cd into the scripts directory and run compile_proto.sh
   4. run python -m minetester.scripts.test_loop
-
-   
-
 

--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,7 @@ setup(
         'numpy',
         'matplotlib',
         'zmq',
-        'protobuf==3.19.0',
+        'protobuf==3.20.1',
         'psutil',
     ],
 )


### PR DESCRIPTION
`setup.py` specified a wrong version for protobuf (3.19.0). This resulted in an import error. 
Here is the updated version (3.20.1).

other small changes:
- `README.md` now mentions `build_instructions.txt`.
- `build_instructions.txt` now explicitly mentions calling `pip install -e ./minetest`