### PR TITLE
fix build on MacOS

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -51,6 +51,12 @@ set(RUN_IN_PLACE ${DEFAULT_RUN_IN_PLACE} CACHE BOOL
 
 set(BUILD_CLIENT TRUE CACHE BOOL "Build client")
 set(BUILD_HEADLESS TRUE CACHE BOOL "Build in headless mode")
+
+if(APPLE AND BUILD_HEADLESS)
+	message(FATAL_ERROR "Headless mode is not supported on MacOS yet. It should be possible, PRs welcome.")
+endif()
+
+
 set(BUILD_SERVER FALSE CACHE BOOL "Build server")
 set(BUILD_UNITTESTS TRUE CACHE BOOL "Build unittests")
 set(BUILD_BENCHMARKS FALSE CACHE BOOL "Build benchmarks")

--- a/cmake/Modules/FindZmqpp.cmake
+++ b/cmake/Modules/FindZmqpp.cmake
@@ -8,10 +8,10 @@ message(${CMAKE_SOURCE_DIR})
 if(ENABLE_SYSTEM_ZMQPP)
 	find_library(ZMQPP_LIBRARY NAMES zmqpp)
 	find_path(ZMQPP_INCLUDE_DIR NAMES zmqpp.hpp PATH_SUFFIXES zmqpp)
-	
+
 	if(ZMQPP_LIBRARY AND ZMQPP_INCLUDE_DIR)
 		message (STATUS "Using ZMQPP provided by system.")
-		set(USE_SYSTEM_GMP TRUE)
+		set(USE_SYSTEM_ZMQPP TRUE)
 	else()
 		message (STATUS "Detecting ZMQPP from system failed.")
 	endif()
@@ -20,17 +20,17 @@ endif()
 
 if(NOT USE_SYSTEM_ZMQPP)
 	message(STATUS "Using ZMQPP submodule")
-	find_path(ZMQPP_INCLUDE_DIR NAMES zmqpp/zmqpp.hpp 
+	find_path(ZMQPP_INCLUDE_DIR NAMES zmqpp/zmqpp.hpp
 		PATHS
 		${CMAKE_SOURCE_DIR}/lib/zmqpp/src/
 		PATH_SUFFIXES zmqpp)
 
-	find_library(ZMQPP_LIBRARY NAMES zmqpp 
-		PATHS ${CMAKE_SOURCE_DIR}/lib/zmqpp/build/max-g++)
+	find_library(ZMQPP_LIBRARY NAMES zmqpp
+		PATHS ${CMAKE_SOURCE_DIR}/lib/zmqpp/build)
 
 	message(${ZMQPP_INCLUDE_DIR})
 	message(${ZMQPP_LIBRARY})
-	
+
 	if(ZMQPP_LIBRARY AND ZMQPP_INCLUDE_DIR)
 		message(STATUS "Using ZMQPP provided by the submodule.")
 	else()

--- a/src/client/client.cpp
+++ b/src/client/client.cpp
@@ -919,10 +919,10 @@ void Client::ReceiveAll()
 	}
 	/*
 	// Get current time
-	auto now = std::chrono::high_resolution_clock::now();
+	auto now = std::chrono::sytem_clock::now();
 
 	// Convert to a time_t object
-	auto now_c = std::chrono::high_resolution_clock::to_time_t(now);
+	auto now_c = std::chrono::system_clock::to_time_t(now);
 
 	// Convert to local time
 	std::tm* now_tm = std::localtime(&now_c);
@@ -1935,10 +1935,10 @@ std::string Client::getInfo() {
 			std::string info(lua_tolstring(L, lua_gettop(L), &str_len));
 
 			// Get current time
-			auto now = std::chrono::high_resolution_clock::now();
+			auto now = std::chrono::system_clock::now();
 
 			// Convert to a time_t object
-			auto now_c = std::chrono::high_resolution_clock::to_time_t(now);
+			auto now_c = std::chrono::system_clock::to_time_t(now);
 
 			// Convert to local time
 			std::tm* now_tm = std::localtime(&now_c);
@@ -1979,10 +1979,10 @@ float Client::getReward() {
 			reward = (float)lua_tonumber(L, lua_gettop(L));
 
 			// Get current time
-			auto now = std::chrono::high_resolution_clock::now();
+			auto now = std::chrono::system_clock::now();
 
 			// Convert to a time_t object
-			auto now_c = std::chrono::high_resolution_clock::to_time_t(now);
+			auto now_c = std::chrono::system_clock::to_time_t(now);
 
 			// Convert to local time
 			std::tm* now_tm = std::localtime(&now_c);

--- a/util/minetester/build_zmqpp.sh
+++ b/util/minetester/build_zmqpp.sh
@@ -1,2 +1,4 @@
 cd lib/zmqpp
+mkdir build
+cmake .. -G "Unix Makefiles"
 make


### PR DESCRIPTION
fix build on MacOS

- Fix zmqpp build:
  When using system zmqpp, previously the wrong variable was being set.
  When building from submodule, previously it was using make in a way that only worked if the compiler was g++. Now we use CMake which works on MacOS.

- In client: don't assume `high_resolution_clock` has `to_time_t`.

Note:
I didn't get the headless support building on MacOS yet. This works with -DBUILD_HEADLESS=FALSE.

This PR is Ready for Review.

## How to test

Build the code.
